### PR TITLE
Add hover animations for department cards

### DIFF
--- a/pages/Offices/scripts/template.js
+++ b/pages/Offices/scripts/template.js
@@ -586,6 +586,19 @@ document.addEventListener("DOMContentLoaded", function () {
     startAutoplay();
 });
 
+document.addEventListener('DOMContentLoaded', () => {
+    const cards = document.querySelectorAll('.card-button');
+    const cardObserver = new IntersectionObserver((entries, obs) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('animate');
+                obs.unobserve(entry.target);
+            }
+        });
+    }, { threshold: 0.1 });
+    cards.forEach(card => cardObserver.observe(card));
+});
+
 // zone
 
 

--- a/pages/Organizations/scripts/template.js
+++ b/pages/Organizations/scripts/template.js
@@ -583,7 +583,20 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
 
-    startAutoplay();
+startAutoplay();
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    const cards = document.querySelectorAll('.card-button');
+    const cardObserver = new IntersectionObserver((entries, obs) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('animate');
+                obs.unobserve(entry.target);
+            }
+        });
+    }, { threshold: 0.1 });
+    cards.forEach(card => cardObserver.observe(card));
 });
 
 // zone

--- a/pages/Other/scripts/template.js
+++ b/pages/Other/scripts/template.js
@@ -586,6 +586,19 @@ document.addEventListener("DOMContentLoaded", function () {
     startAutoplay();
 });
 
+document.addEventListener('DOMContentLoaded', () => {
+    const cards = document.querySelectorAll('.card-button');
+    const cardObserver = new IntersectionObserver((entries, obs) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('animate');
+                obs.unobserve(entry.target);
+            }
+        });
+    }, { threshold: 0.1 });
+    cards.forEach(card => cardObserver.observe(card));
+});
+
 // zone
 
 

--- a/pages/Vice-Chancellors/scripts/template.js
+++ b/pages/Vice-Chancellors/scripts/template.js
@@ -586,6 +586,19 @@ document.addEventListener("DOMContentLoaded", function () {
     startAutoplay();
 });
 
+document.addEventListener('DOMContentLoaded', () => {
+    const cards = document.querySelectorAll('.card-button');
+    const cardObserver = new IntersectionObserver((entries, obs) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('animate');
+                obs.unobserve(entry.target);
+            }
+        });
+    }, { threshold: 0.1 });
+    cards.forEach(card => cardObserver.observe(card));
+});
+
 // zone
 
 

--- a/scripts/main_page.js
+++ b/scripts/main_page.js
@@ -233,7 +233,7 @@ document.addEventListener("DOMContentLoaded", function () {
         statsObserver.observe(item);
     });
 
-    const fadeItems = document.querySelectorAll('.card-item, .stat-item');
+    const fadeItems = document.querySelectorAll('.card-item, .stat-item, .card-button');
     const fadeObserver = new IntersectionObserver((entries, observer) => {
         entries.forEach(entry => {
             if (entry.isIntersecting) {

--- a/styles/main_page.css
+++ b/styles/main_page.css
@@ -866,6 +866,81 @@ a {
   animation: fadeUp 0.6s ease forwards;
 }
 
+.card-button {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 2.5rem;
+  text-align: center;
+  background-color: rgba(255, 255, 255, 0.5);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  border-radius: 16px;
+  text-decoration: none;
+  color: var(--accent-1-color);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  min-height: 180px;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease, transform 0.6s ease, box-shadow 0.3s ease;
+}
+
+.card-button::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 140%;
+  height: 140%;
+  background: radial-gradient(circle at center, rgba(var(--primary-color-rgb), 0.4), rgba(var(--primary-color-rgb), 0) 70%);
+  transform: translate(-50%, -50%) scale(0);
+  opacity: 0;
+  transition: transform 0.5s ease, opacity 0.5s ease;
+  pointer-events: none;
+}
+
+.card-button:hover {
+  transform: translateY(-8px) scale(1.05);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
+  border-color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.8);
+  color: #40E0D0;
+}
+
+.card-button:hover::before {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+}
+
+.card-button h5 {
+  margin-bottom: 0;
+  font-weight: 500;
+  font-size: 1rem;
+  transition: color 0.3s ease;
+}
+
+.card-main-icon {
+  font-size: 2.5rem;
+  transition: transform 0.3s ease, color 0.3s ease;
+  color: #40E0D0;
+}
+
+.card-button:hover .card-main-icon {
+  transform: scale(1.1);
+  color: #40E0D0;
+}
+
+.card-button.animate {
+  opacity: 1;
+  transform: translateY(0);
+  animation: fadeUp 0.6s ease forwards;
+}
+
 .card-text-box {
   text-align: start;
   display: flex;


### PR DESCRIPTION
## Summary
- improve fade-in observer to include `.card-button`
- add glassy card design with hover glow effect
- animate organization, vice-chancellor, office, and other cards on scroll

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_686689422b3c832694e94b94d5f8de84