### PR TITLE
Improve smooth scrolling and zone autoplay

### DIFF
--- a/main_page.html
+++ b/main_page.html
@@ -845,7 +845,6 @@
 <script src="scripts/all.min.js"></script>
 <script src="scripts/main_page.js"></script>
 <script src="scripts/malol.js"></script>
-<script src="images/shahidan.jpg"></script>
 </body>
 
 </html>

--- a/scripts/main_page.js
+++ b/scripts/main_page.js
@@ -793,8 +793,7 @@ document.addEventListener("DOMContentLoaded", function () {
         // For production, you might just hide the section or display a message.
     } else {
         const SCROLL_SPEED = 1;
-        const INTERVAL_TIME = 15;
-        let autoplayZoneInterval = null;
+        let autoplayZoneRequest = null;
 
         // Clone and append/prepend for infinite scroll effect
         originalZoneBoxes.forEach(box => {
@@ -824,19 +823,21 @@ document.addEventListener("DOMContentLoaded", function () {
 
             // When scrolling past the original content, jump back to the start of the cloned content
             if (zoneContainer.scrollLeft >= originalContentWidth * 2) {
-                zoneContainer.classList.add('no-smooth-scroll'); // Temporarily disable smooth scroll for instant jump
+                zoneContainer.classList.add('no-smooth-scroll');
                 zoneContainer.scrollLeft = originalContentWidth;
                 zoneContainer.classList.remove('no-smooth-scroll');
             }
+
+            autoplayZoneRequest = requestAnimationFrame(continuousScroll);
         }
 
         function startAutoplay() {
-            stopAutoplay(); // Clear any existing interval
-            autoplayZoneInterval = setInterval(continuousScroll, INTERVAL_TIME);
+            stopAutoplay();
+            autoplayZoneRequest = requestAnimationFrame(continuousScroll);
         }
 
         function stopAutoplay() {
-            clearInterval(autoplayZoneInterval);
+            cancelAnimationFrame(autoplayZoneRequest);
         }
 
         allZoneBoxes.forEach((link) => {
@@ -866,6 +867,14 @@ document.addEventListener("DOMContentLoaded", function () {
             });
             zoneContainer.scrollLeft = originalContentWidth;
             startAutoplay();
+        });
+
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden) {
+                stopAutoplay();
+            } else {
+                startAutoplay();
+            }
         });
 
         startAutoplay(); // Start autoplay when the DOM is loaded

--- a/styles/main_page.css
+++ b/styles/main_page.css
@@ -3,6 +3,7 @@
 @font-face {
   font-family: shabnam;
   src: url("../fonts/Shabnam.ttf") format("truetype");
+
   font-weight: normal;
   font-display: swap;
 }
@@ -29,6 +30,10 @@
   src: url("../fonts/NotoNastaliqUrdu-Regular.ttf") format("truetype");
   font-weight: normal;
   font-display: swap;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 :root {


### PR DESCRIPTION
## Summary
- smooth scroll for anchor links
- modernize zone slider autoplay to use `requestAnimationFrame`
- stop autoplay when page is hidden
- clean up stray script tag

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866e27cf984832695c3c05fa3cc5edc

## Summary by Sourcery

Improve page navigation and automated zone slider by enabling smooth scroll, switching autoplay to requestAnimationFrame with visibility-based pause/resume, and cleaning up unused script references.

New Features:
- Enable smooth scrolling for anchor link navigation.

Enhancements:
- Modernize zone slider autoplay to use requestAnimationFrame instead of setInterval.
- Pause and resume zone autoplay on page visibility changes.

Chores:
- Remove stray script tag from the HTML.