### PR TITLE
Improve About Us hero section

### DIFF
--- a/pages/about us/styles/about.css
+++ b/pages/about us/styles/about.css
@@ -5,6 +5,53 @@ body.bg {
   font-family: shabnam, sans-serif;
 }
 
+#hero-about {
+  position: relative;
+  background: url("../images/derak-park.jpg") center/cover no-repeat;
+  color: var(--white-color);
+  padding: 120px 0;
+  text-align: center;
+}
+
+#hero-about::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(var(--black-color-rgb), 0.45);
+}
+
+.hero-about-content {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-about-title {
+  font-size: 2.5rem;
+  font-family: shabnamMedium, sans-serif;
+}
+
+.hero-about-subtitle {
+  margin-top: 1rem;
+  font-size: 1.2rem;
+}
+
+.hero-about-title,
+.hero-about-subtitle {
+  opacity: 0;
+  animation: fadeInUp 0.8s ease forwards;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 #services {
   padding: 60px 0;
   position: relative;

--- a/pages/about us/template.html
+++ b/pages/about us/template.html
@@ -181,6 +181,13 @@
 
     <body class="bg">
         <main>
+            <!-- Hero Section -->
+            <section id="hero-about" class="hero-about">
+                <div class="hero-about-content">
+                    <h1 class="hero-about-title">درباره شهرداری شیراز</h1>
+                    <p class="hero-about-subtitle">با تاریخچه و چشم‌انداز شهری ما بیشتر آشنا شوید</p>
+                </div>
+            </section>
             <!-- Section 2: Services -->
             <section id="services">
                 <div class="bg-shape-1"></div>


### PR DESCRIPTION
## Summary
- add a hero section with a headline in the About Us page
- style hero with background image and fade-in animation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868e1fba43483269d4a5ecd58da8e0a