### PR TITLE
Fix layout styles on About page

### DIFF
--- a/pages/about us/styles/about.css
+++ b/pages/about us/styles/about.css
@@ -5,6 +5,24 @@ body.bg {
   font-family: shabnam, sans-serif;
 }
 
+/*
+ * Limit the width of content wrappers so that the
+ * layout stays centered on large screens. This helps
+ * prevent elements from stretching too wide and keeps
+ * a consistent design across sections.
+ */
+.service-timeline,
+.mayor-message-wrapper,
+.showcase-wrapper,
+.quick-links-container,
+.contact-wrapper {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
 #hero-about {
   position: relative;
   background: url("../images/derak-park.jpg") center/cover no-repeat fixed;
@@ -28,6 +46,9 @@ body.bg {
 .hero-about-content {
   position: relative;
   z-index: 1;
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .hero-about-title {
@@ -113,6 +134,10 @@ body.bg {
   border-radius: 12px;
   padding: 1.5rem;
   box-shadow: 0 4px 8px rgba(var(--black-color-rgb), 0.05);
+  width: 100%;
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .service-icon-container {
@@ -179,6 +204,8 @@ body.bg {
   position: relative;
   width: 80%;
   max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .showcase-image {


### PR DESCRIPTION
## Summary
- center content wrappers on the About page so sections don't stretch on large screens
- limit width of hero text and service items

## Testing
- `tidy -errors 'pages/about us/template.html'`

------
https://chatgpt.com/codex/tasks/task_e_686905325d348326806055acc6e5bdf9